### PR TITLE
Michelle_Zhang: add Unit & Integration test for the calculation service

### DIFF
--- a/src/test/java/com/epam/jamp2/mock/FxRateMockData.java
+++ b/src/test/java/com/epam/jamp2/mock/FxRateMockData.java
@@ -1,0 +1,45 @@
+package com.epam.jamp2.mock;
+
+import com.epam.jamp2.model.FixerioResponse;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FxRateMockData {
+
+    public static final String USD = "USD";
+    public static final String CNY = "CNY";
+    public static final String EUR = "EUR";
+
+    public static FixerioResponse mockResponseRates(String baseCurrencyCode) {
+        FixerioResponse response = new FixerioResponse();
+
+        response.setBase(baseCurrencyCode);
+        switch (baseCurrencyCode) {
+            case USD:
+                response.setRates(mockUsdMap());
+                break;
+            case CNY:
+                response.setRates(mockCnyMap());
+                break;
+            default: break;
+        }
+
+        return response;
+    }
+
+    public static Map<String, BigDecimal> mockUsdMap() {
+        Map<String, BigDecimal> ccyMap = new HashMap<>();
+        ccyMap.put(CNY, new BigDecimal(0.146));
+        ccyMap.put(EUR, new BigDecimal(0.946));
+        return ccyMap;
+    }
+
+    public static Map<String, BigDecimal> mockCnyMap() {
+        Map<String, BigDecimal> ccyMap = new HashMap<>();
+        ccyMap.put(USD, new BigDecimal(6.866));
+        ccyMap.put(EUR, new BigDecimal(0.138));
+        return ccyMap;
+    }
+}

--- a/src/test/java/com/epam/jamp2/service/CalculationCommandExecutionServiceIT.java
+++ b/src/test/java/com/epam/jamp2/service/CalculationCommandExecutionServiceIT.java
@@ -1,0 +1,68 @@
+package com.epam.jamp2.service;
+
+import com.epam.jamp2.model.CalculationCommand;
+import com.epam.jamp2.model.CommandFormatException;
+import com.epam.jamp2.model.UnknownCurrencyException;
+import com.epam.jamp2.model.Value;
+import com.epam.jamp2.mock.FxRateMockData;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.number.BigDecimalCloseTo.closeTo;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class CalculationCommandExecutionServiceIT {
+
+    @Autowired
+    private CalculationCommandExecutionService calculationCommandExecutionService;
+
+    // 1 USD ~= 6.866 CNY
+    private static final String ADD_DIDD_CCY = "USD100.0+CNY5.0=CNY";
+    private static final String DIVIDE_SAME_CCY = "CNY100.0/CNY5.0=";
+    private static final String MULTI_RIGHT_CCY_PROVIDED = "100.0*USD5.0=";
+
+    @Test
+    public void testCalcWithDiffCcy() throws CommandFormatException, IOException {
+        CalculationCommand cmd = CalculationCommand.parseFromString(ADD_DIDD_CCY);
+        Value result = calculationCommandExecutionService.calculate(cmd);
+        validateCalculatedValue(result, FxRateMockData.CNY, 691.6, 5.0);
+    }
+
+    @Test
+    public void testCalcWithSameCcy()
+            throws CommandFormatException, IOException, UnknownCurrencyException {
+
+        CalculationCommand cmd = CalculationCommand.parseFromString(DIVIDE_SAME_CCY);
+
+        Value result = calculationCommandExecutionService.calculate(cmd);
+        validateCalculatedValue(result, FxRateMockData.CNY, 20.0, 0.1);
+    }
+
+    @Test
+    public void testCalcWithOnlyOneCcyProvided()
+            throws CommandFormatException, IOException, UnknownCurrencyException {
+
+        CalculationCommand cmd = CalculationCommand.parseFromString(MULTI_RIGHT_CCY_PROVIDED);
+
+        Value result = calculationCommandExecutionService.calculate(cmd);
+        validateCalculatedValue(result, FxRateMockData.USD, 500.0, 0.1);
+    }
+
+    private void validateCalculatedValue(Value result, String expectedCcy, double expectedValue,
+                                         double acceptableDiff) {
+        Assert.assertNotNull(result);
+        Assert.assertThat(result.getCurrencyCode().get(), is(expectedCcy));
+        Assert.assertThat(result.getValue(),
+                is(closeTo(new BigDecimal(expectedValue), new BigDecimal(acceptableDiff))));
+
+    }
+}

--- a/src/test/java/com/epam/jamp2/service/CalculationCommandExecutionServiceIT.java
+++ b/src/test/java/com/epam/jamp2/service/CalculationCommandExecutionServiceIT.java
@@ -34,7 +34,12 @@ public class CalculationCommandExecutionServiceIT {
     public void testCalcWithDiffCcy() throws CommandFormatException, IOException {
         CalculationCommand cmd = CalculationCommand.parseFromString(ADD_DIDD_CCY);
         Value result = calculationCommandExecutionService.calculate(cmd);
-        validateCalculatedValue(result, FxRateMockData.CNY, 691.6, 5.0);
+
+        Assert.assertNotNull(result);
+        Assert.assertThat(result.getCurrencyCode().get(), is(FxRateMockData.CNY));
+        Assert.assertThat(result.getValue(),
+                is(closeTo(new BigDecimal(691.6), new BigDecimal(5.0))));
+
     }
 
     @Test
@@ -44,7 +49,11 @@ public class CalculationCommandExecutionServiceIT {
         CalculationCommand cmd = CalculationCommand.parseFromString(DIVIDE_SAME_CCY);
 
         Value result = calculationCommandExecutionService.calculate(cmd);
-        validateCalculatedValue(result, FxRateMockData.CNY, 20.0, 0.1);
+
+        Assert.assertNotNull(result);
+        Assert.assertThat(result.getCurrencyCode().get(), is(FxRateMockData.CNY));
+        Assert.assertThat(result.getValue(),
+                is(closeTo(new BigDecimal(20.0), new BigDecimal(0.1))));
     }
 
     @Test
@@ -54,15 +63,12 @@ public class CalculationCommandExecutionServiceIT {
         CalculationCommand cmd = CalculationCommand.parseFromString(MULTI_RIGHT_CCY_PROVIDED);
 
         Value result = calculationCommandExecutionService.calculate(cmd);
-        validateCalculatedValue(result, FxRateMockData.USD, 500.0, 0.1);
-    }
 
-    private void validateCalculatedValue(Value result, String expectedCcy, double expectedValue,
-                                         double acceptableDiff) {
         Assert.assertNotNull(result);
-        Assert.assertThat(result.getCurrencyCode().get(), is(expectedCcy));
+        Assert.assertThat(result.getCurrencyCode().get(), is(FxRateMockData.USD));
         Assert.assertThat(result.getValue(),
-                is(closeTo(new BigDecimal(expectedValue), new BigDecimal(acceptableDiff))));
+                is(closeTo(new BigDecimal(500.0), new BigDecimal(0.1))));
 
     }
+
 }

--- a/src/test/java/com/epam/jamp2/service/CalculationCommandExecutionServiceTest.java
+++ b/src/test/java/com/epam/jamp2/service/CalculationCommandExecutionServiceTest.java
@@ -1,0 +1,130 @@
+package com.epam.jamp2.service;
+
+import com.epam.jamp2.model.CalculationCommand;
+import com.epam.jamp2.model.CommandFormatException;
+import com.epam.jamp2.model.UnknownCurrencyException;
+import com.epam.jamp2.model.Value;
+import com.epam.jamp2.mock.FxRateMockData;
+import com.epam.jamp2.service.impl.CalculationCommandExecutionServiceImpl;
+import com.epam.jamp2.service.impl.FxRatesServiceImpl;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.number.BigDecimalCloseTo.closeTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CalculationCommandExecutionServiceTest {
+
+    @Mock
+    private FxRatesServiceImpl fxRatesService;
+
+    @InjectMocks
+    private CalculationCommandExecutionServiceImpl calculationCommandExecutionServiceImpl = new CalculationCommandExecutionServiceImpl();
+
+    private static final String ADD_DIFF_CCY = "USD100.0+CNY5.0=CNY";
+    private static final String ADD_DIFF_CCY_WITHOUT_TARGET_CCY = "CNY100.0+USD5.0=";
+    private static final String DIVIDE_SAME_CCY = "CNY100.0/CNY5.0=";
+    private static final String MULTI_RIGHT_CCY_PROVIDED = "100.0*USD5.0=";
+    private static final String INCORRECT_CMD_FORMAT = "1.0+2.9";
+
+    @Test
+    public void should_pass_4_different_ccy()
+            throws CommandFormatException, IOException, UnknownCurrencyException {
+
+        CalculationCommand cmd = mockCalculationCommand(ADD_DIFF_CCY, 686.6, 5.0, FxRateMockData.CNY);
+
+        Value result = calculationCommandExecutionServiceImpl.calculate(cmd);
+        validateCalculatedValue(result, FxRateMockData.CNY, 691.6, 0.1);
+    }
+
+    @Test
+    public void should_pass_4_same_ccy()
+            throws CommandFormatException, IOException, UnknownCurrencyException {
+
+        CalculationCommand cmd = mockCalculationCommand(DIVIDE_SAME_CCY, 100.0, 5.0, FxRateMockData.CNY);
+
+        Value result = calculationCommandExecutionServiceImpl.calculate(cmd);
+        verify(fxRatesService, never()).convert(anyString(), anyString(), any(BigDecimal.class));
+        validateCalculatedValue(result, FxRateMockData.CNY, 20.0, 0.1);
+    }
+
+    @Test
+    public void should_pass_without_target_ccy()
+            throws CommandFormatException, IOException, UnknownCurrencyException {
+
+        CalculationCommand cmd = mockCalculationCommand(ADD_DIFF_CCY_WITHOUT_TARGET_CCY, 100.0,
+                34.33, FxRateMockData.CNY);
+
+        Value result = calculationCommandExecutionServiceImpl.calculate(cmd);
+        validateCalculatedValue(result, FxRateMockData.CNY, 134.33, 0.1);
+    }
+
+    @Test
+    public void should_pass_ifOnly_right_ccy_provided()
+            throws CommandFormatException, IOException, UnknownCurrencyException {
+
+        CalculationCommand cmd = mockCalculationCommand(MULTI_RIGHT_CCY_PROVIDED, 100.0, 5.0, FxRateMockData.USD);
+
+        Value result = calculationCommandExecutionServiceImpl.calculate(cmd);
+        validateCalculatedValue(result, FxRateMockData.USD, 500.0, 0.1);
+    }
+
+    @Test(expected = CommandFormatException.class)
+    public void should_throw_cmdFormat_error()
+            throws CommandFormatException, IOException, UnknownCurrencyException {
+        CalculationCommand cmd = mockCalculationCommand(INCORRECT_CMD_FORMAT, 1.0, 2.9, FxRateMockData.CNY);
+        calculationCommandExecutionServiceImpl.calculate(cmd);
+    }
+
+    private void validateCalculatedValue(Value result, String expectedCcy, double expectedValue,
+                                         double acceptableDiff) {
+        Assert.assertNotNull(result);
+        Assert.assertThat(result.getCurrencyCode().get(), is(expectedCcy));
+        Assert.assertThat(result.getValue(),
+                is(closeTo(new BigDecimal(expectedValue), new BigDecimal(acceptableDiff))));
+
+    }
+
+    private CalculationCommand mockCalculationCommand(String calFormula, double
+            expectedLeftVal, double expectedRightVal, String expectedCcy)
+            throws CommandFormatException, IOException, UnknownCurrencyException {
+        CalculationCommand cmd = CalculationCommand.parseFromString(calFormula);
+        mockConvertOperations(cmd, expectedLeftVal, expectedRightVal, expectedCcy);
+        return cmd;
+    }
+
+    private void mockConvertOperations(CalculationCommand cmd, double expectedLeftVal,
+                                       double expectedRightVal, String resultCcy)
+            throws IOException, UnknownCurrencyException {
+        Value leftValue = cmd.getLeftOperand();
+        Value rightValue = cmd.getRightOperand();
+        Optional<String> resultCurrencyCode = Optional.of(resultCcy);
+
+        BigDecimal leftOps = new BigDecimal(expectedLeftVal);
+        BigDecimal rightOps = new BigDecimal(expectedRightVal);
+
+        if (leftValue.getCurrencyCode().isPresent()) {
+            when(fxRatesService.convert(leftValue.getCurrencyCode().get(), resultCurrencyCode.get(),
+                    leftValue.getValue())).thenReturn(leftOps);
+        }
+        if (rightValue.getCurrencyCode().isPresent()) {
+            when(fxRatesService.convert(rightValue.getCurrencyCode().get(), resultCurrencyCode.get(),
+                    rightValue.getValue())).thenReturn(rightOps);
+        }
+    }
+
+}

--- a/src/test/java/com/epam/jamp2/service/CalculationCommandExecutionServiceTest.java
+++ b/src/test/java/com/epam/jamp2/service/CalculationCommandExecutionServiceTest.java
@@ -48,7 +48,12 @@ public class CalculationCommandExecutionServiceTest {
         CalculationCommand cmd = mockCalculationCommand(ADD_DIFF_CCY, 686.6, 5.0, FxRateMockData.CNY);
 
         Value result = calculationCommandExecutionServiceImpl.calculate(cmd);
-        validateCalculatedValue(result, FxRateMockData.CNY, 691.6, 0.1);
+
+        Assert.assertNotNull(result);
+        Assert.assertThat(result.getCurrencyCode().get(), is(FxRateMockData.CNY));
+        Assert.assertThat(result.getValue(),
+                is(closeTo(new BigDecimal(691.6), new BigDecimal(0.1))));
+
     }
 
     @Test
@@ -59,7 +64,12 @@ public class CalculationCommandExecutionServiceTest {
 
         Value result = calculationCommandExecutionServiceImpl.calculate(cmd);
         verify(fxRatesService, never()).convert(anyString(), anyString(), any(BigDecimal.class));
-        validateCalculatedValue(result, FxRateMockData.CNY, 20.0, 0.1);
+
+        Assert.assertNotNull(result);
+        Assert.assertThat(result.getCurrencyCode().get(), is(FxRateMockData.CNY));
+        Assert.assertThat(result.getValue(),
+                is(closeTo(new BigDecimal(20.0), new BigDecimal(0.1))));
+
     }
 
     @Test
@@ -70,7 +80,12 @@ public class CalculationCommandExecutionServiceTest {
                 34.33, FxRateMockData.CNY);
 
         Value result = calculationCommandExecutionServiceImpl.calculate(cmd);
-        validateCalculatedValue(result, FxRateMockData.CNY, 134.33, 0.1);
+
+        Assert.assertNotNull(result);
+        Assert.assertThat(result.getCurrencyCode().get(), is(FxRateMockData.CNY));
+        Assert.assertThat(result.getValue(),
+                is(closeTo(new BigDecimal(134.33), new BigDecimal(0.1))));
+
     }
 
     @Test
@@ -80,7 +95,12 @@ public class CalculationCommandExecutionServiceTest {
         CalculationCommand cmd = mockCalculationCommand(MULTI_RIGHT_CCY_PROVIDED, 100.0, 5.0, FxRateMockData.USD);
 
         Value result = calculationCommandExecutionServiceImpl.calculate(cmd);
-        validateCalculatedValue(result, FxRateMockData.USD, 500.0, 0.1);
+
+        Assert.assertNotNull(result);
+        Assert.assertThat(result.getCurrencyCode().get(), is(FxRateMockData.USD));
+        Assert.assertThat(result.getValue(),
+                is(closeTo(new BigDecimal(500.0), new BigDecimal(0.1))));
+
     }
 
     @Test(expected = CommandFormatException.class)
@@ -88,15 +108,6 @@ public class CalculationCommandExecutionServiceTest {
             throws CommandFormatException, IOException, UnknownCurrencyException {
         CalculationCommand cmd = mockCalculationCommand(INCORRECT_CMD_FORMAT, 1.0, 2.9, FxRateMockData.CNY);
         calculationCommandExecutionServiceImpl.calculate(cmd);
-    }
-
-    private void validateCalculatedValue(Value result, String expectedCcy, double expectedValue,
-                                         double acceptableDiff) {
-        Assert.assertNotNull(result);
-        Assert.assertThat(result.getCurrencyCode().get(), is(expectedCcy));
-        Assert.assertThat(result.getValue(),
-                is(closeTo(new BigDecimal(expectedValue), new BigDecimal(acceptableDiff))));
-
     }
 
     private CalculationCommand mockCalculationCommand(String calFormula, double

--- a/src/test/java/com/epam/jamp2/service/FxRatesServiceTest.java
+++ b/src/test/java/com/epam/jamp2/service/FxRatesServiceTest.java
@@ -1,0 +1,66 @@
+package com.epam.jamp2.service;
+
+import com.epam.jamp2.model.FixerioResponse;
+import com.epam.jamp2.model.UnknownCurrencyException;
+import com.epam.jamp2.rest.FixerioServiceProxy;
+import com.epam.jamp2.mock.FxRateMockData;
+import com.epam.jamp2.service.impl.FxRatesServiceImpl;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import retrofit2.Call;
+import retrofit2.Response;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.number.BigDecimalCloseTo.closeTo;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FxRatesServiceTest {
+
+    @Mock
+    private FixerioServiceProxy fixerioServiceProxy;
+
+    @Mock
+    private Call<FixerioResponse> fixerioResponseCall;
+
+    @InjectMocks
+    FxRatesService fxRatesService = new FxRatesServiceImpl();
+
+    @Test
+    public void test_convert_USD_2_CNY() throws IOException, UnknownCurrencyException {
+        mockFxRates(FxRateMockData.USD);
+        BigDecimal convertedValue = fxRatesService.convert(FxRateMockData.USD, FxRateMockData.CNY, new BigDecimal(1000));
+        Assert.assertThat(convertedValue, is(closeTo(new BigDecimal(146.0), new BigDecimal(0.1))));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_no_matched_target_ccy() throws IOException, UnknownCurrencyException {
+        mockFxRates(FxRateMockData.USD);
+        fxRatesService.convert(FxRateMockData.USD, "TES", new BigDecimal(1000));
+    }
+
+    @Test(expected = UnknownCurrencyException.class)
+    public void test_unknown_ccy() throws IOException, UnknownCurrencyException {
+        when(fixerioResponseCall.execute()).thenReturn(Response.success(null));
+        when(fixerioServiceProxy.getRates(FxRateMockData.USD)).thenReturn(fixerioResponseCall);
+
+        fxRatesService.convert(FxRateMockData.USD, FxRateMockData.CNY, new BigDecimal(1000));
+    }
+
+    private void mockFxRates(String fromCcy) throws
+            IOException, UnknownCurrencyException {
+        when(fixerioResponseCall.execute()).thenReturn(mockResponse(fromCcy));
+        when(fixerioServiceProxy.getRates(fromCcy)).thenReturn(fixerioResponseCall);
+    }
+
+    private Response<FixerioResponse> mockResponse(String baseCcy) {
+        return Response.success(FxRateMockData.mockResponseRates(baseCcy));
+    }
+}


### PR DESCRIPTION
@alexeymatyas Here's my implementation for the Unit Test. 

Here's my assumption for the service:
1. If no currency code is provided, e.g. 1+3=, it's treated as incorrect format. 
2. for the integration test, I just checked the online FX rates for USD <-> CNY, and test it with the rate (1USD ~= 6.866CNY).

Besides, when I tried to run the tests by mvn, I found:
1. `mvn test`: will only run the Unit Test class
2. `mvn integration-test`: will run both Unit Test and Integration Test classes
3. `mvn install`: will run both. 
However, I did some search about the maven test command, and it said when running `mvn test`, it should cover both UT and IT classes, while `mvn integration-test` should only for IT classes. This is opposite from my maven run. Do you have any idea about this?

Appreciate if you could provide some comment for my homework. Thanks

